### PR TITLE
Fix an issue in R.path

### DIFF
--- a/src/classes/R.cls
+++ b/src/classes/R.cls
@@ -7368,7 +7368,7 @@ public class R implements Func.IPackage {
             String field = items.get(0);
             Object value = mMap.get(field);
 
-            if(isMapLike(value)) {
+            if(isMapLike(value) && items.size() > 1) {
                 Map<String, Object> subMap = toMap(value);
                 items.remove(0);
                 return this.getValue(subMap, items);


### PR DESCRIPTION
The issue happens when the size of items is only one, and the value is a
map, in which case it would continue to explore the map while the items
list has become empty.